### PR TITLE
modify README.md in switch part

### DIFF
--- a/README.md
+++ b/README.md
@@ -741,7 +741,8 @@ switch (var) {
     case 0:
         do_job();
         break;
-    default: break;
+    default:
+        break;
 }
 
 /* Wrong, default is missing */


### PR DESCRIPTION
To keep the style the same with context, I add an ENTER in the statement of `default: break;`